### PR TITLE
fix: correct Sign Up button URL to open external link properly

### DIFF
--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -20,7 +20,7 @@ const Navbar = () => {
 
   const actionButtons = [
     { path: '/form', label: 'Start your trial', external: false },
-    { path: '"https://portal.qqa.ai"', label: 'Sign Up', external: true },
+    { path: 'https://portal.qqa.ai', label: 'Sign Up', external: true },
   ];
 
   const renderActionButtons = (mode: 'desktop' | 'mobile') =>


### PR DESCRIPTION
Removed extra quotes from the external URL which were causing incorrect routing. Now the "Sign Up" button opens https://portal.qqa.ai in a new tab as expected.